### PR TITLE
sdl2 2.0.10

### DIFF
--- a/Formula/sdl2.rb
+++ b/Formula/sdl2.rb
@@ -1,0 +1,39 @@
+class Sdl2 < Formula
+  desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
+  homepage "https://www.libsdl.org/"
+
+  stable do
+    url "https://libsdl.org/release/SDL2-2.0.10.tar.gz"
+    sha256 "b4656c13a1f0d0023ae2f4a9cf08ec92fffb464e0f24238337784159b8b91d57"
+  end
+
+  bottle do
+    cellar :any
+  end
+
+  head do
+    url "https://hg.libsdl.org/SDL", :using => :hg
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  def install
+    # we have to do this because most build scripts assume that all sdl modules
+    # are installed to the same prefix. Consequently SDL stuff cannot be
+    # keg-only but I doubt that will be needed.
+    inreplace %w[sdl2.pc.in sdl2-config.in], "@prefix@", HOMEBREW_PREFIX
+
+    system "./autogen.sh" if build.head? || build.devel?
+
+    args = %W[--prefix=#{prefix} --without-x]
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system bin/"sdl2-config", "--version"
+  end
+end
+


### PR DESCRIPTION
Seems sdl2 2.0.10 is still blocked on homebrew. So adding it here for now.

related pr: https://github.com/Homebrew/homebrew-core/pull/42619